### PR TITLE
Remove `ls` from `for` loop

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -13,7 +13,7 @@ echo INSTALL COMPILER
 echo -----------------------------------
 for PROG in clang lldb; do
 	sudo apt-get -y install ${PROG}-${CLANG_VERSION}
-	for C in $(ls /usr/bin/${PROG}*${CLANG_VERSION}); do
+	for C in /usr/bin/${PROG}*${CLANG_VERSION}; do
 		L=${C%-$CLANG_VERSION}
 		B=$(basename $L)
 		sudo update-alternatives --install $L $B $C 1000


### PR DESCRIPTION
There is no need to call `ls` to get filenames:  `for` loop does this expansion at evaluation.
Actually, `ls` is an anti-pattern in this case, similar to extra `cat`s.
